### PR TITLE
feat: 上传 API 返回值新增 publicUrl 字段

### DIFF
--- a/functions/upload/chunkMerge.js
+++ b/functions/upload/chunkMerge.js
@@ -3,6 +3,7 @@ import { createResponse, getUploadIp, getIPAddress, selectConsistentChannel, bui
 import { retryFailedChunks, cleanupFailedMultipartUploads, checkChunkUploadStatuses, cleanupChunkData, cleanupUploadSession } from './chunkUpload';
 import { S3Client, CompleteMultipartUploadCommand } from "@aws-sdk/client-s3";
 import { getDatabase } from '../utils/databaseAdapter.js';
+import { fetchPageConfig } from '../utils/sysConfig.js';
 
 // 处理分块合并
 export async function handleChunkMerge(context) {
@@ -111,6 +112,18 @@ async function startMerge(context, uploadId, totalChunks, originalFileName, orig
 
             // 清理上传会话
             await cleanupUploadSession(env, uploadId);
+
+            // 构建公开访问链接（使用 urlPrefix 配置）
+            if (result.result && result.result.length > 0) {
+                const src = result.result[0].src;
+                const fileName = src.startsWith('/file/') ? src.slice(6) : src.split('/file/').pop();
+                const pageConfig = await fetchPageConfig(env);
+                const urlPrefixConfig = pageConfig.config?.find(c => c.id === 'urlPrefix');
+                const urlPrefix = urlPrefixConfig?.value || '';
+                if (urlPrefix) {
+                    result.result[0].publicUrl = `${urlPrefix.replace(/\/+$/, '')}/${fileName}`;
+                }
+            }
 
             return createResponse(JSON.stringify(result.result), {
                 status: 200,

--- a/functions/upload/chunkUpload.js
+++ b/functions/upload/chunkUpload.js
@@ -4,6 +4,7 @@ import { TelegramAPI } from '../utils/storage/telegramAPI';
 import { DiscordAPI } from '../utils/storage/discordAPI';
 import { S3Client, CreateMultipartUploadCommand, UploadPartCommand, AbortMultipartUploadCommand } from "@aws-sdk/client-s3";
 import { getDatabase, checkDatabaseConfig } from '../utils/databaseAdapter.js';
+import { fetchPageConfig } from '../utils/sysConfig.js';
 
 // 初始化分块上传
 export async function initializeChunkedUpload(context) {
@@ -1271,8 +1272,17 @@ export async function uploadLargeFileToTelegram(context, file, fullId, metadata,
         // 异步结束上传
         waitUntil(endUpload(context, fullId, metadata));
 
+        // 构建公开访问链接（使用 urlPrefix 配置）
+        const pageConfig = await fetchPageConfig(env);
+        const urlPrefixConfig = pageConfig.config?.find(c => c.id === 'urlPrefix');
+        const urlPrefix = urlPrefixConfig?.value || '';
+        const responseBody = [{ 'src': returnLink }];
+        if (urlPrefix) {
+            responseBody[0].publicUrl = `${urlPrefix.replace(/\/+$/, '')}/${fullId}`;
+        }
+
         return createResponse(
-            JSON.stringify([{ 'src': returnLink }]),
+            JSON.stringify(responseBody),
             {
                 status: 200,
                 headers: {

--- a/functions/upload/index.js
+++ b/functions/upload/index.js
@@ -1,5 +1,5 @@
 import { userAuthCheck, UnauthorizedResponse } from "../utils/auth/userAuth";
-import { fetchUploadConfig, fetchSecurityConfig } from "../utils/sysConfig";
+import { fetchUploadConfig, fetchSecurityConfig, fetchPageConfig } from "../utils/sysConfig";
 import {
     createResponse, getUploadIp, getIPAddress, resolveFileExt,
     moderateContent, purgeCDNCache, isBlockedUploadIp, buildUniqueFileId, endUpload, getImageDimensions,
@@ -200,6 +200,12 @@ async function processFileUpload(context, formdata = null) {
         returnLink = `/file/${fullId}`;
     }
 
+    // 构建公开访问链接（使用 urlPrefix 配置）
+    const pageConfig = await fetchPageConfig(context.env);
+    const urlPrefixConfig = pageConfig.config?.find(c => c.id === 'urlPrefix');
+    const urlPrefix = urlPrefixConfig?.value || '';
+    context.publicUrl = urlPrefix ? `${urlPrefix.replace(/\/+$/, '')}/${fullId}` : '';
+
     /* ====================================不同渠道上传======================================= */
     // 出错是否切换渠道自动重试，默认开启
     const autoRetry = url.searchParams.get('autoRetry') === 'false' ? false : true;
@@ -265,6 +271,19 @@ async function processFileUpload(context, formdata = null) {
     return res;
 }
 
+// 构建上传成功响应，自动附带 publicUrl（如果已配置）
+function buildUploadResponse(context, returnLink) {
+    const result = { src: returnLink };
+    if (context.publicUrl) {
+        result.publicUrl = context.publicUrl;
+    }
+    return createResponse(JSON.stringify([result]), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+}
+
 // 上传到Cloudflare R2
 async function uploadFileToCloudflareR2(context, fullId, metadata, returnLink) {
     const { env, waitUntil, uploadConfig, formdata, specifiedChannelName } = context;
@@ -317,15 +336,7 @@ async function uploadFileToCloudflareR2(context, fullId, metadata, returnLink) {
     waitUntil(endUpload(context, fullId, metadata));
 
     // 成功上传，将文件ID返回给客户端
-    return createResponse(
-        JSON.stringify([{ 'src': `${returnLink}` }]),
-        {
-            status: 200,
-            headers: {
-                'Content-Type': 'application/json',
-            }
-        }
-    );
+    return buildUploadResponse(context, returnLink);
 }
 
 
@@ -417,12 +428,7 @@ async function uploadFileToS3(context, fullId, metadata, returnLink) {
         // 结束上传
         waitUntil(endUpload(context, fullId, metadata));
 
-        return createResponse(JSON.stringify([{ src: returnLink }]), {
-            status: 200,
-            headers: {
-                "Content-Type": "application/json",
-            },
-        });
+        return buildUploadResponse(context, returnLink);
     } catch (error) {
         return createResponse(`Error: Failed to upload to S3 - ${error.message}`, { status: 500 });
     }
@@ -515,15 +521,7 @@ async function uploadFileToTelegram(context, fullId, metadata, fileExt, fileName
         metadata.FileSize = (fileInfo.file_size / 1024 / 1024).toFixed(2);
 
         // 将响应返回给客户端
-        res = createResponse(
-            JSON.stringify([{ 'src': `${returnLink}` }]),
-            {
-                status: 200,
-                headers: {
-                    'Content-Type': 'application/json',
-                }
-            }
-        );
+        res = buildUploadResponse(context, returnLink);
 
 
         // 图像审查（使用代理域名或官方域名）
@@ -583,15 +581,7 @@ async function uploadFileToExternal(context, fullId, metadata, returnLink) {
     waitUntil(endUpload(context, fullId, metadata));
 
     // 返回结果
-    return createResponse(
-        JSON.stringify([{ 'src': `${returnLink}` }]),
-        {
-            status: 200,
-            headers: {
-                'Content-Type': 'application/json',
-            }
-        }
-    );
+    return buildUploadResponse(context, returnLink);
 }
 
 
@@ -671,13 +661,7 @@ async function uploadFileToDiscord(context, fullId, metadata, returnLink) {
         waitUntil(endUpload(context, fullId, metadata));
 
         // 返回成功响应
-        return createResponse(
-            JSON.stringify([{ 'src': returnLink }]),
-            {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            }
-        );
+        return buildUploadResponse(context, returnLink);
 
     } catch (error) {
         console.error('Discord upload error:', error.message);
@@ -791,13 +775,7 @@ async function uploadFileToHuggingFace(context, fullId, metadata, returnLink) {
         waitUntil(endUpload(context, fullId, metadata));
 
         // 返回成功响应
-        return createResponse(
-            JSON.stringify([{ 'src': returnLink }]),
-            {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            }
-        );
+        return buildUploadResponse(context, returnLink);
 
     } catch (error) {
         console.error('HuggingFace upload error:', error.message);
@@ -872,13 +850,7 @@ async function uploadFileToWebDAV(context, fullId, metadata, returnLink) {
 
         waitUntil(endUpload(context, fullId, metadata));
 
-        return createResponse(
-            JSON.stringify([{ 'src': returnLink }]),
-            {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            }
-        );
+        return buildUploadResponse(context, returnLink);
     } catch (error) {
         console.error('WebDAV upload error:', error.message);
         return createResponse(`Error: WebDAV upload failed - ${error.message}`, { status: 500 });


### PR DESCRIPTION
## 概述

上传 API 的返回值中新增 `publicUrl` 字段，提供实际可访问的 CDN/对象存储链接，与原有的 `src` 字段（返回应用代理路径 `/file/...`）互补。

## 背景

项目在系统设置中已有"默认 URL 前缀"（`urlPrefix`）配置项，管理面板和前端文件列表都会用它来展示文件的可访问链接。但上传 API 的返回值此前从未包含这个信息，导致 API 调用方需要手动拼接 URL。用户既然配置了 `urlPrefix`，自然希望上传接口也能直接返回对应的完整路径，这样更便捷。

## 修改内容

### 涉及文件

- `functions/upload/index.js` — 主上传处理
- `functions/upload/chunkUpload.js` — 分块上传（Telegram 大文件）
- `functions/upload/chunkMerge.js` — 分块合并完成

### 具体改动

1. **`index.js`**：`processFileUpload()` 读取 `urlPrefix` 配置并存入 `context.publicUrl`。新增 `buildUploadResponse()` 辅助函数构造响应 JSON，在 `urlPrefix` 已配置时附带 `publicUrl`。文件中 7 处响应构造全部改用此辅助函数。

2. **`chunkUpload.js`**：`uploadLargeFileToTelegram()` 同样读取 `urlPrefix` 并在响应中返回 `publicUrl`。

3. **`chunkMerge.js`**：分块合并成功响应中读取 `urlPrefix` 并附带 `publicUrl`。

### 返回格式

当配置了 `urlPrefix`（如 `https://cdn.example.com`）：

```json
[{
  "src": "/file/1781206167354_example.png",
  "publicUrl": "https://cdn.example.com/1781206167354_example.png"
}]
```

未配置 `urlPrefix` 时，不返回 `publicUrl` 字段——行为完全向后兼容。

## 设计决策

### 为什么新增字段而不是替换 `src`？

`src` 字段（`/file/...`）在内部代理访问场景下仍有价值。新增 `publicUrl` 字段是增量式、非破坏性的改动。

### 为什么每次上传都读取 `urlPrefix` 配置？

`urlPrefix` 配置存储在 KV/D1 中，运行时可能变更。每次上传时读取可保证与当前管理面板设置一致。`fetchPageConfig()` 内置了错误处理，失败时返回 `{ config: [] }`，不会阻塞上传流程。

### 带 path 的 urlPrefix 兼容性

如果 `urlPrefix` 包含路径（如 `https://cdn.example.com/files`），能正确拼接——末尾斜杠会被去除，文件 ID 以 `/` 分隔追加。

### 作用范围说明

`urlPrefix` 是全局配置。当配置了多个存储后端（R2、Telegram 等），`publicUrl` 基于这个全局前缀构建。这与管理面板和前端文件列表的现有行为一致——它们也对所有渠道使用同一个全局前缀。这是上游项目已有的设计取舍，非本次 PR 引入。

