### PR TITLE
fix(fetchRes): prevent SSRF in server-side URL proxy

### DIFF
--- a/functions/api/fetchRes.js
+++ b/functions/api/fetchRes.js
@@ -4,6 +4,58 @@
  */
 import { dualAuthCheck } from '../utils/auth/dualAuth.js';
 
+/**
+ * Determine whether a hostname refers to a private, loopback, link-local,
+ * cloud-metadata, or otherwise internal network address. Used to prevent
+ * SSRF against internal services from the proxy endpoint.
+ *
+ * @param {string} hostname - hostname or IP literal from a parsed URL
+ * @returns {boolean}
+ */
+function isPrivateHostname(hostname) {
+    if (!hostname) return true;
+    let h = hostname.toLowerCase();
+    // Strip IPv6 brackets
+    if (h.startsWith('[') && h.endsWith(']')) {
+        h = h.slice(1, -1);
+    }
+
+    // Obvious local names
+    if (h === 'localhost' || h === 'ip6-localhost' || h === 'ip6-loopback') return true;
+    if (h.endsWith('.localhost') || h.endsWith('.local') || h.endsWith('.internal')) return true;
+
+    // Cloud metadata service hostnames
+    if (h === 'metadata.google.internal' || h === 'metadata.goog') return true;
+
+    // IPv4 literal check
+    const ipv4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (ipv4) {
+        const [a, b] = [parseInt(ipv4[1], 10), parseInt(ipv4[2], 10)];
+        if (a === 10) return true;                              // 10.0.0.0/8
+        if (a === 127) return true;                             // loopback
+        if (a === 0) return true;                               // 0.0.0.0/8
+        if (a === 169 && b === 254) return true;                // link-local / AWS metadata 169.254.169.254
+        if (a === 172 && b >= 16 && b <= 31) return true;       // 172.16.0.0/12
+        if (a === 192 && b === 168) return true;                // 192.168.0.0/16
+        if (a === 100 && b >= 64 && b <= 127) return true;      // CGNAT 100.64.0.0/10
+        if (a >= 224) return true;                              // multicast / reserved
+        return false;
+    }
+
+    // IPv6 literal check (basic)
+    if (h.includes(':')) {
+        if (h === '::' || h === '::1') return true;
+        if (h.startsWith('fe80:') || h.startsWith('fe80::')) return true;   // link-local
+        if (h.startsWith('fc') || h.startsWith('fd')) return true;          // unique local fc00::/7
+        // IPv4-mapped IPv6 (::ffff:a.b.c.d)
+        const mapped = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+        if (mapped) return isPrivateHostname(mapped[1]);
+        return false;
+    }
+
+    return false;
+}
+
 export async function onRequest(context) {
     // 获取请求体中URL的内容
     const {
@@ -30,9 +82,63 @@ export async function onRequest(context) {
     if (targetUrl === undefined) {
         return new Response('URL is required', { status: 400 })
     }
-    const response = await fetch(targetUrl);
+
+    // Validate the target URL to mitigate SSRF (CWE-918).
+    let parsed;
+    try {
+        parsed = new URL(targetUrl);
+    } catch (e) {
+        return new Response(JSON.stringify({ error: 'Invalid URL' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    // Only allow http(s); block file:, gopher:, data:, ftp:, blob:, etc.
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return new Response(JSON.stringify({ error: 'Only http(s) URLs are allowed' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    // Refuse embedded credentials (used to smuggle auth into internal targets).
+    if (parsed.username || parsed.password) {
+        return new Response(JSON.stringify({ error: 'Credentials in URL are not allowed' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    // Block private / loopback / link-local / metadata targets.
+    if (isPrivateHostname(parsed.hostname)) {
+        return new Response(JSON.stringify({ error: 'Access to internal addresses is not allowed' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    // Follow redirects manually so a permitted host cannot redirect us onto
+    // an internal address without re-validation.
+    let response = await fetch(parsed.toString(), { redirect: 'manual' });
+    let hops = 0;
+    while (response.status >= 300 && response.status < 400 && response.headers.get('location') && hops < 5) {
+        const next = new URL(response.headers.get('location'), parsed);
+        if ((next.protocol !== 'http:' && next.protocol !== 'https:') ||
+            next.username || next.password ||
+            isPrivateHostname(next.hostname)) {
+            return new Response(JSON.stringify({ error: 'Redirect to disallowed target' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        response = await fetch(next.toString(), { redirect: 'manual' });
+        hops++;
+    }
+
     const headers = new Headers(response.headers);
     return new Response(response.body, {
-        headers: headers
+        headers: headers,
+        status: response.status
     })
 }


### PR DESCRIPTION
## Summary

`functions/api/fetchRes.js` is a server-side URL fetch proxy: it accepts a `url` field in the request body and returns the fetched response to the caller. The endpoint is gated by `dualAuthCheck` (admin or user token), but any authenticated user could ask the server to fetch **any** URL, including internal / loopback / cloud-metadata targets. This is a classic Server-Side Request Forgery (CWE-918).

Pre-fix, the entire fetch was:

```javascript
const response = await fetch(targetUrl);
```

No URL parsing, no protocol allowlist, no host filtering, no redirect handling.

## Impact

An authenticated user (or anyone who has obtained a user token — note the project allows self-registration/user tokens in typical deployments) could:

- Fetch cloud metadata: `http://169.254.169.254/latest/meta-data/iam/security-credentials/` on any AWS-backed deployment, `http://metadata.google.internal/` on GCP, etc.
- Probe/interact with internal HTTP services reachable from the deployment (admin panels, Redis HTTP frontends, Kubernetes API, etc.).
- Use non-HTTP protocols the runtime happens to support (`file:`, `gopher:`, `ftp:`, `data:`) to read local resources or speak raw TCP where applicable.
- Bypass any naive host check by pointing at an attacker-controlled host that 302-redirects to an internal target — `fetch` follows redirects by default.

The authenticated-user precondition does **not** already grant an attacker outbound network access from the server to arbitrary internal addresses, so exploiting this endpoint is a genuine capability escalation (attacker's browser → server-side actor on the deployment's internal network).

## Fix

The change is confined to `functions/api/fetchRes.js` (+108 / -2). It adds, before the `fetch` call:

1. **URL parsing with `new URL(...)`** in a `try/catch`, so malformed input is rejected with 400 rather than propagated.
2. **Protocol allowlist**: only `http:` and `https:` are accepted. Blocks `file:`, `gopher:`, `data:`, `ftp:`, `blob:`, etc.
3. **Reject embedded credentials** (`user:pass@host`) — commonly used to smuggle auth at internal targets and to confuse URL parsers.
4. **`isPrivateHostname()`** covering:
   - IPv4: `10.0.0.0/8`, `127.0.0.0/8`, `0.0.0.0/8`, `169.254.0.0/16` (includes AWS/Azure/GCP metadata `169.254.169.254`), `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (CGNAT), `224.0.0.0/4` and above (multicast/reserved).
   - IPv6: `::`, `::1`, `fe80::/10` link-local, `fc00::/7` unique-local, and IPv4-mapped `::ffff:a.b.c.d` (recursed through the IPv4 check).
   - Hostnames: `localhost`, `*.localhost`, `*.local`, `*.internal`, `metadata.google.internal`, `metadata.goog`.
5. **Manual redirect handling** (`redirect: 'manual'`, up to 5 hops), re-running the same validation on every `Location` — this closes the redirect-to-internal bypass.

The response status is now also propagated (previously always defaulted to 200), which is a small correctness improvement.

## Proof of Concept

With a valid user or admin cookie/token for a deployed instance:

```bash
# 1. Baseline — public URL still works
curl -X POST https://<host>/api/fetchRes \
  -H 'Cookie: <auth cookie>' \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://example.com/"}'

# 2. Pre-fix: server fetches AWS metadata and returns the body to the caller
curl -X POST https://<host>/api/fetchRes \
  -H 'Cookie: <auth cookie>' \
  -H 'Content-Type: application/json' \
  -d '{"url":"http://169.254.169.254/latest/meta-data/"}'

# 3. Pre-fix: file:// on runtimes whose fetch honors it
curl -X POST https://<host>/api/fetchRes \
  -H 'Cookie: <auth cookie>' \
  -H 'Content-Type: application/json' \
  -d '{"url":"file:///etc/passwd"}'

# 4. Pre-fix: redirect bypass — attacker hosts /redir that 302s to 127.0.0.1
curl -X POST https://<host>/api/fetchRes \
  -H 'Cookie: <auth cookie>' \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://attacker.example/redir-to-loopback"}'
```

Post-fix, requests 2–4 all return HTTP 400 with a JSON error (`Access to internal addresses is not allowed`, `Only http(s) URLs are allowed`, or `Redirect to disallowed target`). Request 1 still succeeds.

The affected file (`functions/api/fetchRes.js`) and the auth helper (`functions/utils/auth/dualAuth.js` → `dualAuthCheck`) both exist on `main` in this repo, so the PoC is grounded in the actual codebase.

## Tests performed locally

- Parsed a range of hostile inputs through `isPrivateHostname`: `127.0.0.1`, `169.254.169.254`, `10.0.0.5`, `172.16.0.1`, `172.31.255.255`, `172.32.0.1` (correctly *not* private), `192.168.1.1`, `100.64.0.1`, `::1`, `::ffff:127.0.0.1`, `fe80::1`, `fd00::1`, `metadata.google.internal`, `foo.local`, `localhost`. All classified as expected.
- Verified `new URL('http://user:pass@127.0.0.1/')` populates `username`/`password` and is rejected by the credential check.
- Verified `new URL('file:///etc/passwd').protocol === 'file:'` and is rejected by the protocol check.
- Verified a public URL (e.g. `https://example.com/`) still parses cleanly and reaches the `fetch`.

## Adversarial review

Before submitting we tried to disprove this finding. Two things to rule out:

1. *Does the auth gate already give the attacker equivalent access?* No. `dualAuthCheck` accepts a normal user token; it does not grant shell or outbound network access on the deployment. Being able to make the server issue arbitrary internal HTTP requests is strictly more than what the token grants on its own.
2. *Does the Cloudflare Workers runtime already block `169.254.169.254` / `file:` / private ranges?* Workers `fetch` does refuse some non-HTTP schemes and has its own egress rules on the managed edge, but this project also ships a Docker image (published on Docker Hub) alongside the Cloudflare Pages deployment path. In the Docker deployment, `fetch` runs under standard Node with no such restrictions, so metadata IPs and private ranges are reachable. A defense-in-depth hostname allowlist in application code is the right layer regardless.

Residual risk we consciously did not try to fix here: DNS rebinding between validation and the actual `fetch`. Fully closing that requires resolving the hostname ourselves and pinning the socket to the resolved IP, which isn't practical on Workers `fetch`. Documenting it as a known limitation.